### PR TITLE
Fix missing os import in config

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -1,5 +1,6 @@
 from dotenv import load_dotenv
 load_dotenv()
+import os
 
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 BASE_URL = os.getenv("BASE_URL")


### PR DESCRIPTION
## Summary
- add `os` import in `core/config.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'telegram')*

------
https://chatgpt.com/codex/tasks/task_e_6867dc73e2848324a5f2ed143a6d7932